### PR TITLE
refactor: change default value to null in blade-formatter config

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ If you want to disable this completion feature, set `blade.completion.enable` to
 - `blade.completion.exclude`: Exclude specific prefix in snippet completion, e.g. `["b:extends", "lv:url", "Blade::component"]`, default: `[]`
 - `blade.bladeFormatter.enable`: Enable/Disable the formatting feature by `blade-formatter`, default: `true`
 - `blade.bladeFormatter.toolPath`: Absolute path to blade-formatter. If there is no setting, the built-in blade-formatter will be used, default: `""`
-- `blade.bladeFormatter.optIndentSize`: Indent size (`--indent-size`), default: `4`
-- `blade.bladeFormatter.optWrapLineLength`: The length of line wrap size (`--wrap-line-length`), default: `120`
-- `blade.bladeFormatter.optWrapAttributes`: The way to wrap attributes (`--wrap-attributes`), valid options `["auto", "force", "force-aligned", "force-expand-multiline", "aligned-multiple", "preserve", "preserve-aligned"]`, default: `"auto"`
+- `blade.bladeFormatter.optIndentSize`: Indent size (`--indent-size`), valid type `integer` or `null`, default: `null`,
+- `blade.bladeFormatter.optWrapLineLength`: The length of line wrap size (`--wrap-line-length`), valid type `integer` or `null`, default: `null`
+- `blade.bladeFormatter.optWrapAttributes`: The way to wrap attributes (`--wrap-attributes`), valid options `["auto", "force", "force-aligned", "force-expand-multiline", "aligned-multiple", "preserve", "preserve-aligned"]`, valid type `string` or `null`, default: `null`
 - `blade.bladeLinter.enable`: Enable/Disable the linting feature by `laravel-blade-linter`, default: `true`
 
 ## Commands

--- a/package.json
+++ b/package.json
@@ -97,18 +97,27 @@
           "description": "Absolute path to blade-formatter. If there is no setting, the built-in blade-formatter will be used"
         },
         "blade.bladeFormatter.optIndentSize": {
-          "type": "integer",
-          "default": 4,
+          "type": [
+            null,
+            "integer"
+          ],
+          "default": null,
           "markdownDescription": "Indent size"
         },
         "blade.bladeFormatter.optWrapLineLength": {
-          "type": "integer",
-          "default": 120,
+          "type": [
+            null,
+            "integer"
+          ],
+          "default": null,
           "markdownDescription": "The length of line wrap size"
         },
         "blade.bladeFormatter.optWrapAttributes": {
-          "type": "string",
-          "default": "auto",
+          "type": [
+            null,
+            "string"
+          ],
+          "default": null,
           "enum": [
             "auto",
             "force",

--- a/src/format.ts
+++ b/src/format.ts
@@ -31,9 +31,9 @@ export async function doFormat(
 
   const extConfig = workspace.getConfiguration('blade.bladeFormatter');
 
-  const formatIndentSize = extConfig.get('optIndentSize', 4);
-  const formatWrapLineLength = extConfig.get('optWrapLineLength', 120);
-  const formatWrapAttributes = extConfig.get('optWrapAttributes', 'auto');
+  const formatIndentSize = extConfig.get('optIndentSize', null);
+  const formatWrapLineLength = extConfig.get('optWrapLineLength', null);
+  const formatWrapAttributes = extConfig.get('optWrapAttributes', null);
 
   let toolPath = extConfig.get('toolPath', '');
   if (!toolPath) {
@@ -54,9 +54,9 @@ export async function doFormat(
   const cwd = Uri.file(workspace.root).fsPath;
   const opts = { cwd, shell: true };
 
-  args.push(`--indent-size ${formatIndentSize}`);
-  args.push(`--wrap-line-length ${formatWrapLineLength}`);
-  args.push(`--wrap-attributes ${formatWrapAttributes}`);
+  if (formatIndentSize) args.push(`--indent-size ${formatIndentSize}`);
+  if (formatWrapLineLength) args.push(`--wrap-line-length ${formatWrapLineLength}`);
+  if (formatWrapAttributes) args.push(`--wrap-attributes ${formatWrapAttributes}`);
 
   args.push('--stdin');
 


### PR DESCRIPTION
## Description

A configuration file has been added in blade-fromatter v1.17.0.

- **REF**:
  - <https://github.com/shufo/blade-formatter#configuring-blade-formatter>
    - `.bladeformatterrc.json` or `.bladeformatterrc`

The current version of "coc-blade" is run by passing options to the blade-formatter command.

In the current blade-formatter (v1.17.1), if `.bladeFormatterrc.json` exists, the configuration in `.bladeformatterrc.json` seems to take precedence even if the option is passed to the command.

However, there may be changes in behavior in the future.

## Changes

All `blade.bladeFormatter.optXXXX` settings change the default value to `null`.

If it is `null`, the command will be executed without adding each option to the `blade-formatter` command.

## Misc

In `v1.17.0`, the `--`stdin setting was not respected, but this has been fixed in `v1.17.1`.

- **REF**:
  - <https://github.com/shufo/blade-formatter/issues/458>
  - <https://github.com/shufo/blade-formatter/pull/461>