### PR TITLE
refactor: remove "blade.bladeFormatter.toolPath" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ If you want to disable this completion feature, set `blade.completion.enable` to
 - `blade.completion.enable`: Enable snippets completion, default: `true`
 - `blade.completion.exclude`: Exclude specific prefix in snippet completion, e.g. `["b:extends", "lv:url", "Blade::component"]`, default: `[]`
 - `blade.bladeFormatter.enable`: Enable/Disable the formatting feature by `blade-formatter`, default: `true`
-- `blade.bladeFormatter.toolPath`: Absolute path to blade-formatter. If there is no setting, the built-in blade-formatter will be used, default: `""`
 - `blade.bladeFormatter.optIndentSize`: Indent size (`--indent-size`), valid type `integer` or `null`, default: `null`,
 - `blade.bladeFormatter.optWrapLineLength`: The length of line wrap size (`--wrap-line-length`), valid type `integer` or `null`, default: `null`
 - `blade.bladeFormatter.optWrapAttributes`: The way to wrap attributes (`--wrap-attributes`), valid options `["auto", "force", "force-aligned", "force-expand-multiline", "aligned-multiple", "preserve", "preserve-aligned"]`, valid type `string` or `null`, default: `null`

--- a/package.json
+++ b/package.json
@@ -104,11 +104,6 @@
           "default": true,
           "markdownDescription": "Enable/Disable the formatting feature by blade-formatter"
         },
-        "blade.bladeFormatter.toolPath": {
-          "type": "string",
-          "default": "",
-          "description": "Absolute path to blade-formatter. If there is no setting, the built-in blade-formatter will be used"
-        },
         "blade.bladeFormatter.optIndentSize": {
           "type": [
             null,

--- a/src/format.ts
+++ b/src/format.ts
@@ -40,22 +40,7 @@ export async function doFormat(
   const formatWrapLineLength = extConfig.get('optWrapLineLength', defaultWrapLineLength);
   const formatWrapAttributes = extConfig.get('optWrapAttributes', defaultWrapAttributes);
 
-  let toolPath = extConfig.get('toolPath', '');
-  if (!toolPath) {
-    if (fs.existsSync(context.asAbsolutePath('node_modules/blade-formatter/bin/blade-formatter'))) {
-      toolPath = context.asAbsolutePath('node_modules/blade-formatter/bin/blade-formatter');
-    } else {
-      window.showErrorMessage('Unable to find the blade-formatter.');
-      return originalText;
-    }
-  } else {
-    if (!fs.existsSync(toolPath)) {
-      window.showErrorMessage('Unable to find the blade-formatter (user setting).');
-      return originalText;
-    }
-  }
-
-  const args: FormatterOption = {
+  const options: FormatterOption = {
     indentSize: formatIndentSize,
     wrapAttributes: formatWrapAttributes,
     wrapLineLength: formatWrapLineLength,
@@ -67,9 +52,8 @@ export async function doFormat(
   // ---- Output the command to be executed to channel log. ----
   outputChannel.appendLine(`${'#'.repeat(10)} blade-formatter\n`);
   outputChannel.appendLine(`Cwd: ${opts.cwd}`);
-  outputChannel.appendLine(`Args: ${JSON.stringify(args)}`);
+  outputChannel.appendLine(`Option: ${JSON.stringify(options)}`);
   outputChannel.appendLine(`File: ${fileName}`);
-  outputChannel.appendLine(`Run: ${toolPath} ${JSON.stringify(args)}`);
 
   const isIgnoreFile = shouldIgnore(fileName, outputChannel);
   if (isIgnoreFile) {
@@ -84,7 +68,7 @@ export async function doFormat(
 
     try {
       // try formatting in worker thread
-      newText = syncFn(originalText, args);
+      newText = syncFn(originalText, options);
       outputChannel.appendLine(`\n==== STDOUT ===\n`);
       outputChannel.appendLine(`${newText}`);
       outputChannel.appendLine(`== success ==`);


### PR DESCRIPTION
The execution method of blade-formatter has been changed from `cli` to `api`.

Because of this, the options for cli will be removed.

**See**:

- <https://github.com/yaegassy/coc-blade/pull/5>
