### PR TITLE
Add "blade.showReferences" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Parses `bootstrap/cache/livewire-components.php` files and target component clas
 
 - `blade.showOutput`: Show blade output channel
 - `blade.bladeFormatter.run`: Run blade-formatter
+- `blade.showReferences`: Show BladeDirective (`@...`) or BladeEcho (`{{ ... }}`, `{!! ... !!}`) location information for the current file
 
 ## Code Actions
 

--- a/package.json
+++ b/package.json
@@ -276,6 +276,10 @@
       {
         "command": "blade.bladeFormatter.run",
         "title": "Run bladeFormatter.run"
+      },
+      {
+        "command": "blade.showReferences",
+        "title": "Show BladeDirective (`@...`) or BladeEcho (`{{ ... }}`, `{!! ... !!}`) location information for the current file"
       }
     ]
   },

--- a/src/commands/showReferences.ts
+++ b/src/commands/showReferences.ts
@@ -1,0 +1,79 @@
+import { commands, ExtensionContext, Location, OutputChannel, Position, Range, Uri, workspace } from 'coc.nvim';
+
+import { BladeDocument } from 'stillat-blade-parser/out/document/bladeDocument';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { BladeEchoNode, DirectiveNode } from 'stillat-blade-parser/out/nodes/nodes';
+
+type BladeReferenceType = {
+  startLine: number;
+  startChar: number;
+  endLine: number;
+  endChar: number;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export async function register(context: ExtensionContext, _outputChannel: OutputChannel) {
+  context.subscriptions.push(
+    commands.registerCommand('blade.showReferences', async () => {
+      const { document, position } = await workspace.getCurrentState();
+      if (document.languageId !== 'blade') return;
+
+      const refs: BladeReferenceType[] = [];
+      const text = document.getText();
+      const parsedBladeDoc = BladeDocument.fromText(text);
+
+      parsedBladeDoc.getAllNodes().forEach((node) => {
+        if (node instanceof DirectiveNode) {
+          if (node.namePosition) {
+            if (node.namePosition.start && node.namePosition.end) {
+              refs.push({
+                startLine: node.namePosition.start.line - 1,
+                startChar: node.namePosition.start.char - 1,
+                endLine: node.namePosition.end.line - 1,
+                endChar: node.namePosition.end.char,
+              });
+            }
+          }
+        }
+
+        if (node instanceof BladeEchoNode) {
+          if (node.startPosition && node.endPosition) {
+            let fixStartPosChar = 1;
+            if (node.sourceContent.startsWith('{{')) {
+              fixStartPosChar = 2;
+            }
+            refs.push({
+              startLine: node.startPosition.line - 1,
+              startChar: node.startPosition.char - fixStartPosChar,
+              endLine: node.endPosition.line - 1,
+              endChar: node.endPosition.char,
+            });
+          }
+        }
+
+        //if (node instanceof BladeComponentNode) {
+        //  if (node.startPosition && node.endPosition) {
+        //    refs.push({
+        //      startLine: node.startPosition.line - 1,
+        //      startChar: node.startPosition.char - 1,
+        //      endLine: node.endPosition.line - 1,
+        //      endChar: node.endPosition.char,
+        //    });
+        //  }
+        //}
+      });
+
+      commands.executeCommand(
+        'editor.action.showReferences',
+        Uri.parse(document.uri),
+        position,
+        refs.map((ref) =>
+          Location.create(
+            document.uri,
+            Range.create(Position.create(ref.startLine, ref.startChar), Position.create(ref.endLine, ref.endChar))
+          )
+        )
+      );
+    })
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { getConfigBladeEnable } from './config';
 import * as bladeCodeActionFeature from './actions/action';
 import * as bladeFormatterRunCommandFeature from './commands/bladeFormatterRun';
 import * as showOutputCommandFeature from './commands/showOutput';
+import * as bladeShowReferencesCommandFeature from './commands/showReferences';
 import * as bladeCompletionFeature from './completions/completion';
 import * as bladeDefinisionFeature from './definitions/definition';
 import * as bladeFormatterDocumantFormattingEditFeature from './documentFormats/documentFormat';
@@ -18,6 +19,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   showOutputCommandFeature.register(context, outputChannel);
   bladeFormatterRunCommandFeature.register(context, outputChannel);
+  bladeShowReferencesCommandFeature.register(context, outputChannel);
   await bladeCompletionFeature.register(context, outputChannel);
   bladeFormatterDocumantFormattingEditFeature.register(context, outputChannel);
   bladeHoverFeature.register(context);


### PR DESCRIPTION
## Description

I added a command to display the location information of BladeDirective (`@...`) and BladeEcho (`{{ ... }}`, `{!! ... !!}`).

Initially, I tried to add it as a feature of the document symbol, but a bug was found in `coc.nvim` itself that prevented it from working properly when used together with `coc-html`. It seems that the `html.filetypes` setting of `coc-html` is related to this issue...

Therefore, we have added it as a dedicated command feature.

## Command

- `blade.showReferences`
  - Show BladeDirective (`@...`) or BladeEcho (`{{ ... }}`, `{!! ... !!}`) location information for the current file

## DEMO (mp4)

https://user-images.githubusercontent.com/188642/234866210-d843514e-d1ba-4dd2-88aa-9232f1c02833.mp4
