### PR TITLE
Add the large-sized dependencies of the stillat-blade-parser package to esbuild's external

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -7,7 +7,9 @@ async function start(watch) {
     minify: process.env.NODE_ENV === 'production',
     sourcemap: process.env.NODE_ENV === 'development',
     mainFields: ['module', 'main'],
-    external: ['coc.nvim'],
+    // add the large-sized dependencies of the stillat-blade-parser package to external
+    // - 'prettier', '@prettier/plugin-php', '@stedi/prettier-plugin-jsonata', 'jsonata'
+    external: ['coc.nvim', 'prettier', '@prettier/plugin-php', '@stedi/prettier-plugin-jsonata', 'jsonata'],
     platform: 'node',
     target: 'node14.14',
     outfile: 'lib/index.js',


### PR DESCRIPTION
## Description

I had the maintainer adjust the dependencies of the `stillat-blade-parser` package. However, as a result, the size of the bundled output with "esbuild" has become significantly larger.

- <https://github.com/Stillat/blade-parser-typescript/issues/30>

I added the configuration to esbuild's external settings because I believe that bundling large packages like Prettier is unnecessary when using it solely as a parser.

### Before (unpacked size: "10.2 MB")

```
$ npm publish --dry-run
npm notice
npm notice 📦  coc-blade@0.16.1
npm notice === Tarball Contents ===
// ...snip
npm notice === Tarball Details ===
npm notice name:          coc-blade
npm notice version:       0.16.1
npm notice filename:      coc-blade-0.16.1.tgz
npm notice package size:  1.8 MB
npm notice unpacked size: 10.2 MB
npm notice shasum:        6a70a09dd616e350fa192212476a80a36def8eb9
npm notice integrity:     sha512-ssTtvcmmKMQPZ[...]PeISCdK4iKjJQ==
npm notice total files:   72
npm notice
npm notice Publishing to https://registry.npmjs.org/ with tag latest and default access (dry-run)
+ coc-blade@0.16.1
```

### After (unpacked size: "812.0 kB")

```
$ npm publish --dry-run
npm notice
npm notice 📦  coc-blade@0.16.1
npm notice === Tarball Contents ===
// ...snip
npm notice === Tarball Details ===
npm notice name:          coc-blade
npm notice version:       0.16.1
npm notice filename:      coc-blade-0.16.1.tgz
npm notice package size:  129.2 kB
npm notice unpacked size: 812.0 kB
npm notice shasum:        52b7fea497e1bf6d749eca4f5e197e3efc6147b4
npm notice integrity:     sha512-z6ow0zfDZntb2[...]o1JsWMgwOeeCg==
npm notice total files:   72
npm notice
npm notice Publishing to https://registry.npmjs.org/ with tag latest and default access (dry-run)
+ coc-blade@0.16.1
```